### PR TITLE
feat: bootstrap Preact in index

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,13 +31,18 @@
     </nav>
 
     <main id="app-content">
-        <!-- Content will be loaded here by the router -->
-        <div class="loading">Loading...</div>
+        <div id="app"></div>
     </main>
 
     <button id="add-button" class="fab" aria-label="Add new">+</button>
 
-    <script type="module" src="ui/app.js"></script>
+    <script type="module">
+        import { html, render } from 'https://esm.sh/htm/preact/standalone';
+        import Router from 'https://esm.sh/preact-router';
+        import App from './ui/app.js';
+
+        render(html`<${App}/>`, document.getElementById('app'));
+    </script>
     <script>
         // Register service worker
         if ('serviceWorker' in navigator) {


### PR DESCRIPTION
## Summary
- add Preact and router imports in an inline module
- provide an `#app` container for rendering
- move service worker registration below the new bootstrap code

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ac3e82cf0832286c107187738a2f4