### PR TITLE
feat: add signals-based state store

### DIFF
--- a/state/store.js
+++ b/state/store.js
@@ -1,0 +1,26 @@
+import { signal } from 'https://esm.sh/@preact/signals@latest?deps=preact@10';
+import * as AreaTypeModel from '../models/areaType.js';
+
+// Signals
+export const areaTypes = signal([]);
+
+// Actions
+export async function loadAreaTypes() {
+  areaTypes.value = await AreaTypeModel.getAll();
+}
+
+export async function createAreaType(areaType) {
+  const id = await AreaTypeModel.create(areaType);
+  areaTypes.value = [...areaTypes.value, { id, ...areaType }];
+  return id;
+}
+
+export async function updateAreaType(areaType) {
+  await AreaTypeModel.update(areaType);
+  areaTypes.value = areaTypes.value.map(at => at.id === areaType.id ? areaType : at);
+}
+
+export async function removeAreaType(id) {
+  await AreaTypeModel.remove(id);
+  areaTypes.value = areaTypes.value.filter(at => at.id !== id);
+}

--- a/ui/areaTypes.js
+++ b/ui/areaTypes.js
@@ -1,10 +1,11 @@
 import { html, useState, useEffect } from 'https://esm.sh/htm/preact/standalone';
 import { route } from 'https://esm.sh/preact-router';
+import { areaTypes, loadAreaTypes, createAreaType, updateAreaType, removeAreaType } from '../state/store.js';
 import * as AreaTypeModel from '../models/areaType.js';
 
 export function AreaTypeList() {
-  const [types, setTypes] = useState([]);
-  useEffect(() => { AreaTypeModel.getAll().then(setTypes); }, []);
+  useEffect(() => { loadAreaTypes(); }, []);
+  const types = areaTypes.value;
   return html`
     <div class="card">
       <h2>Area Types</h2>
@@ -60,7 +61,7 @@ export function AreaTypeCreate() {
     e.preventDefault();
     if (!name.trim()) return alert('Please enter a name');
     try {
-      await AreaTypeModel.create({ name });
+      await createAreaType({ name });
       route('/area-types');
     } catch (err) {
       alert('Error creating area type: ' + err.message);
@@ -92,7 +93,7 @@ export function AreaTypeEdit({ id }) {
     e.preventDefault();
     if (!name.trim()) return alert('Please enter a name');
     try {
-      await AreaTypeModel.update({ id: parseInt(id), name });
+      await updateAreaType({ id: parseInt(id), name });
       route('/area-types');
     } catch (err) {
       alert('Error updating area type: ' + err.message);
@@ -101,7 +102,7 @@ export function AreaTypeEdit({ id }) {
   const remove = async () => {
     if (!confirm('Are you sure you want to delete this area type? This will also delete all associated areas.')) return;
     try {
-      await AreaTypeModel.remove(parseInt(id));
+      await removeAreaType(parseInt(id));
       route('/area-types');
     } catch (err) {
       alert('Error deleting area type: ' + err.message);


### PR DESCRIPTION
## Summary
- introduce a signals-powered state store for area types
- refactor area and area type UI to consume signals and actions

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689accaaaae4832295c509ed0f78201e