### PR TITLE
Add router-aware navigation and floating add button

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -118,6 +118,11 @@ nav a:hover, nav a:focus {
     background-color: var(--primary-light);
 }
 
+nav li.active > a {
+    background-color: var(--primary-light);
+    font-weight: bold;
+}
+
 /* Main content */
 main {
     padding: 1rem;

--- a/ui/App.js
+++ b/ui/App.js
@@ -1,6 +1,7 @@
-import { html } from 'https://esm.sh/htm/preact/standalone';
-import Router from 'https://esm.sh/preact-router';
+import { html, useState } from 'https://esm.sh/htm/preact/standalone';
+import Router, { route } from 'https://esm.sh/preact-router';
 import { Nav } from './nav.js';
+import { AddButton } from './addButton.js';
 import { AreaTypeList, AreaTypeDetail, AreaTypeCreate, AreaTypeEdit } from './areaTypes.js';
 import { AreaList, AreaDetail, AreaCreate, AreaEdit } from './areas.js';
 import { AreaGroupList, AreaGroupDetail, AreaGroupCreate, AreaGroupEdit } from './areaGroups.js';
@@ -10,32 +11,43 @@ import { ItemPartDetail, ItemPartCreate, ItemPartEdit } from './itemParts.js';
 // Simple placeholder component for routes
 const Placeholder = ({ title }) => html`<div class="card"><h2>${title}</h2></div>`;
 
-export const App = () => html`
-  <${Nav}/>
-  <main id="app-content">
-    <${Router}>
-      <${Placeholder} path="/" title="Home" />
-      <${AreaTypeList} path="/area-types" />
-      <${AreaTypeDetail} path="/area-types/:id" />
-      <${AreaTypeCreate} path="/area-types/new" />
-      <${AreaTypeEdit} path="/area-types/:id/edit" />
-      <${AreaList} path="/areas" />
-      <${AreaDetail} path="/areas/:id" />
-      <${AreaCreate} path="/areas/new" />
-      <${AreaEdit} path="/areas/:id/edit" />
-      <${AreaGroupList} path="/area-groups" />
-      <${AreaGroupDetail} path="/area-groups/:id" />
-      <${AreaGroupCreate} path="/area-groups/new" />
-      <${AreaGroupEdit} path="/area-groups/:id/edit" />
-      <${ItemList} path="/items" />
-      <${ItemDetail} path="/items/:id" />
-      <${ItemCreate} path="/items/new" />
-      <${ItemEdit} path="/items/:id/edit" />
-      <${ItemPartCreate} path="/item-parts/new" />
-      <${ItemPartDetail} path="/item-parts/:id" />
-      <${ItemPartEdit} path="/item-parts/:id/edit" />
-      <${Placeholder} path="/export-import" title="Export/Import" />
-    <//>
-  </main>
-`;
+export const App = () => {
+  const [currentUrl, setCurrentUrl] = useState(typeof window !== 'undefined' ? window.location.pathname : '/');
+  const addHandlers = {
+    '/area-types': () => route('/area-types/new'),
+    '/areas': () => route('/areas/new'),
+    '/area-groups': () => route('/area-groups/new'),
+    '/items': () => route('/items/new')
+  };
+  const onAdd = addHandlers[currentUrl];
+  return html`
+    <${Nav} currentUrl=${currentUrl}/>
+    <main id="app-content">
+      <${Router} onChange=${e => setCurrentUrl(e.url)}>
+        <${Placeholder} path="/" title="Home" />
+        <${AreaTypeList} path="/area-types" />
+        <${AreaTypeDetail} path="/area-types/:id" />
+        <${AreaTypeCreate} path="/area-types/new" />
+        <${AreaTypeEdit} path="/area-types/:id/edit" />
+        <${AreaList} path="/areas" />
+        <${AreaDetail} path="/areas/:id" />
+        <${AreaCreate} path="/areas/new" />
+        <${AreaEdit} path="/areas/:id/edit" />
+        <${AreaGroupList} path="/area-groups" />
+        <${AreaGroupDetail} path="/area-groups/:id" />
+        <${AreaGroupCreate} path="/area-groups/new" />
+        <${AreaGroupEdit} path="/area-groups/:id/edit" />
+        <${ItemList} path="/items" />
+        <${ItemDetail} path="/items/:id" />
+        <${ItemCreate} path="/items/new" />
+        <${ItemEdit} path="/items/:id/edit" />
+        <${ItemPartCreate} path="/item-parts/new" />
+        <${ItemPartDetail} path="/item-parts/:id" />
+        <${ItemPartEdit} path="/item-parts/:id/edit" />
+        <${Placeholder} path="/export-import" title="Export/Import" />
+      <//>
+    </main>
+    <${AddButton} onClick=${onAdd} />
+  `;
+};
 

--- a/ui/addButton.js
+++ b/ui/addButton.js
@@ -1,0 +1,7 @@
+import { html } from 'https://esm.sh/htm/preact/standalone';
+
+export const AddButton = ({ onClick }) => {
+  if (!onClick) return null;
+  return html`<button id="add-button" class="fab" aria-label="Add" onClick=${onClick}>+</button>`;
+};
+

--- a/ui/nav.js
+++ b/ui/nav.js
@@ -2,9 +2,10 @@ import { html, useState } from 'https://esm.sh/htm/preact/standalone';
 import { Link } from 'https://esm.sh/preact-router';
 
 // Navigation component using preact-router Link
-export const Nav = () => {
+export const Nav = ({ currentUrl }) => {
   const [open, setOpen] = useState(false);
   const close = () => setOpen(false);
+  const isActive = href => currentUrl && currentUrl.startsWith(href);
   return html`
     <header>
       <h1>Home-Clean</h1>
@@ -13,11 +14,11 @@ export const Nav = () => {
     <nav id="main-nav" class=${open ? 'visible' : 'hidden'}>
       <button id="close-menu" aria-label="Close menu" onClick=${close}>✕</button>
       <ul>
-        <li><${Link} href="/area-types" onClick=${close}>Area Types<//></li>
-        <li><${Link} href="/areas" onClick=${close}>Areas<//></li>
-        <li><${Link} href="/area-groups" onClick=${close}>Area Groups<//></li>
-        <li><${Link} href="/items" onClick=${close}>Items<//></li>
-        <li><${Link} href="/export-import" onClick=${close}>Export/Import<//></li>
+        <li class=${isActive('/area-types') ? 'active' : ''}><${Link} href="/area-types" onClick=${close}>Area Types<//></li>
+        <li class=${isActive('/areas') ? 'active' : ''}><${Link} href="/areas" onClick=${close}>Areas<//></li>
+        <li class=${isActive('/area-groups') ? 'active' : ''}><${Link} href="/area-groups" onClick=${close}>Area Groups<//></li>
+        <li class=${isActive('/items') ? 'active' : ''}><${Link} href="/items" onClick=${close}>Items<//></li>
+        <li class=${isActive('/export-import') ? 'active' : ''}><${Link} href="/export-import" onClick=${close}>Export/Import<//></li>
       </ul>
     </nav>
   `;


### PR DESCRIPTION
## Summary
- convert navigation into router-aware Preact component with menu state
- introduce reusable floating AddButton and route-driven handlers in App
- style active nav links for better user feedback

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689acf61ee588322a26f3a3266705a26