### PR TITLE
Clean up legacy DOM IDs and document Preact stack

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,6 +1,8 @@
 # Home-Clean PWA Installation Guide
 
 This document provides detailed instructions for installing and deploying the Home-Clean PWA.
+The project uses [Preact](https://preactjs.com/) with [HTM](https://github.com/developit/htm) for templating and a small state
+manager built on [preact signals](https://preactjs.com/guide/v10/signals/).
 
 ## Local Development
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Home-Clean PWA
 
-A 100% offline-first, single-user Progressive Web App (PWA) that helps you track cleaning and maintenance tasks for items in your home.
+A 100% offline-first, single-user Progressive Web App (PWA) that helps you track cleaning and maintenance tasks for items in your home. The interface is built with [Preact](https://preactjs.com/) using [HTM](https://github.com/developit/htm) for JSX-free templating and a small state manager powered by [preact signals](https://preactjs.com/guide/v10/signals/).
 
 ## Features
 
@@ -116,7 +116,8 @@ To backup or transfer your data:
 
 ## Technical Details
 
-- Built with [Preact](https://preactjs.com/) and [`preact-router`](https://github.com/preactjs/preact-router)
+- Built with [Preact](https://preactjs.com/), [HTM](https://github.com/developit/htm) and [`preact-router`](https://github.com/preactjs/preact-router)
+- State managed with a lightweight [preact signals](https://preactjs.com/guide/v10/signals/) store (`state/store.js`)
 - Uses IndexedDB for local storage via the lightweight idb library
 - Implements the Progressive Web App standard for offline functionality
 - Responsive design works on mobile and desktop devices

--- a/ui/App.js
+++ b/ui/App.js
@@ -22,7 +22,7 @@ export const App = () => {
   const onAdd = addHandlers[currentUrl];
   return html`
     <${Nav} currentUrl=${currentUrl}/>
-    <main id="app-content">
+    <main>
       <${Router} onChange=${e => setCurrentUrl(e.url)}>
         <${Placeholder} path="/" title="Home" />
         <${AreaTypeList} path="/area-types" />

--- a/ui/addButton.js
+++ b/ui/addButton.js
@@ -2,6 +2,6 @@ import { html } from 'https://esm.sh/htm/preact/standalone';
 
 export const AddButton = ({ onClick }) => {
   if (!onClick) return null;
-  return html`<button id="add-button" class="fab" aria-label="Add" onClick=${onClick}>+</button>`;
+  return html`<button class="fab" aria-label="Add" onClick=${onClick}>+</button>`;
 };
 

--- a/ui/nav.js
+++ b/ui/nav.js
@@ -11,7 +11,7 @@ export const Nav = ({ currentUrl }) => {
       <h1>Home-Clean</h1>
       <button id="menu-toggle" aria-label="Menu" onClick=${() => setOpen(true)}>≡</button>
     </header>
-    <nav id="main-nav" class=${open ? 'visible' : 'hidden'}>
+    <nav class=${open ? 'visible' : 'hidden'}>
       <button id="close-menu" aria-label="Close menu" onClick=${close}>✕</button>
       <ul>
         <li class=${isActive('/area-types') ? 'active' : ''}><${Link} href="/area-types" onClick=${close}>Area Types<//></li>


### PR DESCRIPTION
## Summary
- drop leftover DOM IDs from navigation, add button and main container now handled by components
- document use of Preact, HTM and signal-based state manager in README and installation guide

## Testing
- `npm test` (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_689adc78e1b08322a70902b86fc24197